### PR TITLE
Fix incorrect icon import

### DIFF
--- a/components/timezone-card.tsx
+++ b/components/timezone-card.tsx
@@ -5,7 +5,7 @@ import type React from "react"
 import { useState, useEffect } from "react"
 import { format } from "date-fns"
 import { toZonedTime, fromZonedTime } from "date-fns-tz"
-import { Copy, Trash2, Clock, MoreHorizontal, EqualIcon, ChevronsRight, ChevronsLeft } from "lucide-react"
+import { Copy, Trash2, Clock, MoreHorizontal, Equal, ChevronsRight, ChevronsLeft } from "lucide-react"
 import { Card, CardContent } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -143,7 +143,7 @@ export function TimezoneCard({
                   className="h-8 w-8 rounded-full hover:bg-background/20"
                   aria-label="More options"
                 >
-                  <EqualIcon className="h-6 w-6" />
+                  <Equal className="h-6 w-6" />
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end" >


### PR DESCRIPTION
## Summary
- fix invalid icon name in `TimezoneCard`

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842e7072b84832bb71aadc2ef20c6b1