### PR TITLE
Enable drag-and-drop reordering for cards

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -165,36 +165,29 @@ export default function TimezoneApp() {
     setAutoUpdate(true)
   }
 
-  const onMoveLeft = (index : number) => {
-    console.log("🔥 ~ onMoveLeft ~ index:", index, timezones)
-    if ( index === 0) { 
-      return
-    }
-    else {
-      console.log("🔥 ~ onMoveLeft ~ else:")
+  // Drag and drop handlers
+  const [draggedIndex, setDraggedIndex] = useState<number | null>(null)
 
-    const updatedTimezones = [...timezones]; // Create a new array
-    [updatedTimezones[index - 1], updatedTimezones[index]] = [updatedTimezones[index], updatedTimezones[index - 1]]; // Swap
-
-
-      console.log("🔥 ~ onMoveLeft ~ timezones:", updatedTimezones)
-      setTimezones(updatedTimezones)
-    }
-   
+  const handleDragStart = (index: number) => {
+    setDraggedIndex(index)
   }
 
-  const onMoveRight = (index : number) => {
+  const handleDragOver = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault()
+  }
 
-    if ( index === timezones.length - 1) { 
+  const handleDrop = (index: number) => {
+    if (draggedIndex === null || draggedIndex === index) {
+      setDraggedIndex(null)
       return
     }
-    else {
-    const updatedTimezones = [...timezones]; // Create a new array
-    [updatedTimezones[index + 1], updatedTimezones[index]] = [updatedTimezones[index], updatedTimezones[index + 1]]; // Swap
-
-      setTimezones(updatedTimezones)
-    }
+    const updatedTimezones = [...timezones]
+    const [moved] = updatedTimezones.splice(draggedIndex, 1)
+    updatedTimezones.splice(index, 0, moved)
+    setDraggedIndex(null)
+    setTimezones(updatedTimezones)
   }
+
 
   // Filter timezones based on search query
   const filteredTimezones = allTimezones.filter(
@@ -333,21 +326,26 @@ export default function TimezoneApp() {
 
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mt-4 pb-20">
           {timezones.map((timezone, index) => (
-            <TimezoneCard
+            <div
               key={timezone}
-              timezone={timezone}
-              label={timezoneLabels[timezone] || timezone.replace(/_/g, " ")}
-              currentDateTime={currentDateTime}
-              onTimeChange={updateTime}
-              onCopy={() => copyTimeToClipboard(timezone)}
-              onRemove={() => removeTimezone(timezone)}
-              onMoveLeft={() => onMoveLeft(index)}
-              onMoveRight={() => onMoveRight(index)}
-              onRename={(label) => renameTimezone(timezone, label)}
-              compact={compactView}
-              isLocal={timezone === userTimezone}
-              colorIndex={index}
-            />
+              draggable
+              onDragStart={() => handleDragStart(index)}
+              onDragOver={handleDragOver}
+              onDrop={() => handleDrop(index)}
+            >
+              <TimezoneCard
+                timezone={timezone}
+                label={timezoneLabels[timezone] || timezone.replace(/_/g, " ")}
+                currentDateTime={currentDateTime}
+                onTimeChange={updateTime}
+                onCopy={() => copyTimeToClipboard(timezone)}
+                onRemove={() => removeTimezone(timezone)}
+                onRename={(label) => renameTimezone(timezone, label)}
+                compact={compactView}
+                isLocal={timezone === userTimezone}
+                colorIndex={index}
+              />
+            </div>
           ))}
         </div>
       </div>

--- a/components/timezone-card.tsx
+++ b/components/timezone-card.tsx
@@ -5,7 +5,7 @@ import type React from "react"
 import { useState, useEffect } from "react"
 import { format } from "date-fns"
 import { toZonedTime, fromZonedTime } from "date-fns-tz"
-import { Copy, Trash2, Clock, MoreHorizontal, Equal, ChevronsRight, ChevronsLeft, Pencil } from "lucide-react"
+import { Copy, Trash2, Equal, Pencil } from "lucide-react"
 import { Card, CardContent } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -53,8 +53,6 @@ interface TimezoneCardProps {
   onTimeChange: (newTime: Date, timezone: string) => void
   onCopy: () => void
   onRemove: () => void
-  onMoveLeft: (index: number) => void
-  onMoveRight: (index: number) => void
   onRename: (label: string) => void
   colorIndex: number
   compact: boolean
@@ -68,8 +66,6 @@ export function TimezoneCard({
   onTimeChange,
   onCopy,
   onRemove,
-  onMoveLeft ,
-  onMoveRight ,
   onRename,
   colorIndex,
   compact,
@@ -167,15 +163,6 @@ export function TimezoneCard({
                   <Pencil className="mr-2 h-3 w-3" /> Rename
                 </DropdownMenuItem>
                 <hr />
-                <DropdownMenuItem onClick={() => onMoveLeft(colorIndex)} >
-                  <ChevronsLeft className="mr-2 h-3 w-3 text-sm" />
-                  Move Left
-                </DropdownMenuItem>
-                <DropdownMenuItem onClick={() => onMoveRight(colorIndex)} >
-                  <ChevronsRight className="mr-2 h-3 w-3 text-sm" />
-                  Move Right
-                </DropdownMenuItem>
-                <hr></hr>
                 <DropdownMenuItem onClick={handleDelete} className="text-sm text-destructive focus:text-destructive">
                   <Trash2 className="mr-2 h-3 w-3" />
                   Delete


### PR DESCRIPTION
## Summary
- add drag and drop handlers in page
- remove old Move Left/Move Right menu items
- store new order in localStorage automatically

## Testing
- `pnpm lint` *(fails: next not found)*
- `pnpm build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842f3bc3dc0832b89159cbf6c6951d9