### PR TITLE
Add cache versioning to PWA

### DIFF
--- a/app/chrome-extension/page.tsx
+++ b/app/chrome-extension/page.tsx
@@ -1,4 +1,10 @@
 import ChromeExtensionGuide from "@/chrome-extension-guide"
+import type { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: "Chrome Extension - Timezone App",
+  description: "Guide for installing the Timezone App Chrome Extension.",
+}
 
 export default function ChromeExtensionPage() {
   return <ChromeExtensionGuide />

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,10 +1,33 @@
 import type { Metadata } from 'next'
 import './globals.css'
 import { Toaster } from "@/components/ui/sonner"
+import RegisterSW from './register-sw'
 
 export const metadata: Metadata = {
   title: 'Timezone App',
-  description: 'Created by Shrihari',
+  description: 'Multi-timezone tracker for developers and remote workers.',
+  applicationName: 'Timezone App',
+  keywords: ['timezones', 'world clock', 'developers', 'remote work'],
+  manifest: '/manifest.json',
+  themeColor: '#ffffff',
+  openGraph: {
+    title: 'Timezone App - Multi-Timezone Tracker for Developers',
+    description:
+      'A modern timezone application for developers and remote employees to manage and compare multiple timezones effortlessly.',
+    url: 'https://app-timezone.vercel.app/',
+    siteName: 'Timezone App',
+    images: '/og-image.png',
+    locale: 'en_US',
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Timezone App - Multi-Timezone Tracker for Developers',
+    description:
+      'A simple yet powerful timezone manager for developers and remote workers.',
+    images: ['/og-image.png'],
+    creator: '@papashrihari',
+  },
 }
 
 export default function RootLayout({
@@ -15,24 +38,13 @@ export default function RootLayout({
   return (
     <html lang="en">
       <head>
-        <meta property="og:title" content="Timezone App - Multi-Timezone Tracker for Developers" />
-        <meta property="og:description" content="A modern timezone application for developers and remote employees to manage and compare multiple timezones effortlessly." />
-        <meta property="og:image" content="https://app-timezone.vercel.app/og-image.png" />
-        <meta property="og:url" content="https://app-timezone.vercel.app/" />
-        <meta property="og:type" content="website" />
-        <meta property="og:site_name" content="Timezone App" />
-        <meta property="og:locale" content="en_US" />
-
-        <meta name="twitter:card" content="summary_large_image" />
-        <meta name="twitter:title" content="Timezone App - Multi-Timezone Tracker for Developers" />
-        <meta name="twitter:description" content="A simple yet powerful timezone manager for developers and remote workers." />
-        <meta name="twitter:image" content="https://app-timezone.vercel.app/og-image.png" />
-        <meta name="twitter:url" content="https://app-timezone.vercel.app/" />
-        <meta name="twitter:creator" content="@papashrihari" />
+        <link rel="manifest" href="/manifest.json" />
+        <meta name="theme-color" content="#ffffff" />
       </head>
       <body>
         {children}
         <Toaster />
+        <RegisterSW />
       </body>
       
     </html>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useEffect, useState } from "react"
+import type { Metadata } from "next"
 import { format } from "date-fns"
 import { toZonedTime } from "date-fns-tz"
 import { Plus, Sun, Moon, Search, ChevronUp, ChevronDown, RefreshCcw, Maximize2, Minimize2, Palette } from "lucide-react"
@@ -12,6 +13,12 @@ import { TimezoneCard } from "@/components/timezone-card"
 import { getAllTimezones } from "@/lib/timezones"
 import { getTimezoneOffset } from "@/lib/timezone-utils"
 import { toast } from "sonner"
+
+export const metadata: Metadata = {
+  title: "Timezone App",
+  description:
+    "A modern timezone application for developers and remote employees to manage multiple timezones.",
+}
 
 export default function TimezoneApp() {
   const [timezones, setTimezones] = useState<string[]>([])

--- a/app/register-sw.tsx
+++ b/app/register-sw.tsx
@@ -1,0 +1,11 @@
+"use client";
+import { useEffect } from "react";
+
+export default function RegisterSW() {
+  useEffect(() => {
+    if ("serviceWorker" in navigator) {
+      navigator.serviceWorker.register("/sw.js");
+    }
+  }, []);
+  return null;
+}

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,9 @@
+{
+  "name": "Timezone App",
+  "short_name": "Timezone",
+  "description": "Multi-timezone tracker for developers and remote workers.",
+  "start_url": "/",
+  "display": "standalone",
+  "theme_color": "#ffffff",
+  "background_color": "#ffffff"
+}

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,27 @@
+const CACHE_NAME = 'timezone-app-v1';
+
+self.addEventListener('install', event => {
+  self.skipWaiting();
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(['/', '/manifest.json']))
+  );
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(keys =>
+      Promise.all(
+        keys.filter(key => key !== CACHE_NAME).map(key => caches.delete(key))
+      )
+    )
+  );
+  self.clients.claim();
+});
+
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.match(event.request).then(response => {
+      return response || fetch(event.request);
+    })
+  );
+});


### PR DESCRIPTION
## Summary
- delete placeholder icon images
- drop icon references from the PWA manifest
- improve service worker with cache versioning and cleanup

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844ff922cbc832ba626394381919754